### PR TITLE
Define STRICT_R_HEADERS, use M_PI

### DIFF
--- a/src/calco.cpp
+++ b/src/calco.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <math.h> 
 #include <iostream>
@@ -56,9 +57,9 @@ NumericVector calCo(NumericMatrix prev_atoms, double length, double bAngle, doub
   _v       = (_SvdV-u3)/dis2;
   _w       =NumericVector::create(_u[1]*_v[2]-_u[2]*_v[1], _u[2]*_v[0]-_u[0]*_v[2], _u[0]*_v[1]-_u[1]*_v[0]);
     
-  n_res    = cur_res + _u*length*cos(PI-bAngle)
-  + _v*length*sin(PI-bAngle)*cos(tAngle)
-  + _w*length*sin(PI-bAngle)*sin(tAngle);
+  n_res    = cur_res + _u*length*cos(M_PI-bAngle)
+  + _v*length*sin(M_PI-bAngle)*cos(tAngle)
+  + _w*length*sin(M_PI-bAngle)*sin(tAngle);
   
   return n_res;
   


### PR DESCRIPTION
Dear Samuel, dear compas team,

Your CRAN package compas uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at
  https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context on this.

First off, I hope I have the right repo. On CRAN it is compas with one s, here it is compass with two s -- and the set of files is slightly different.  I can email you a suggested patch for the CRAN version if you prefer.  But GitHub may be easier.

Here, I prefixed one #include <Rcpp.h> with STRICT_R_HEADERS (it could also be added in all files if you prefer) and made one additional change that is needed by moving from PI to M_PI.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
  https://github.com/RcppCore/Rcpp/issues/1158
to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.